### PR TITLE
Correctif pour le bug #5 - install ignore login mysql

### DIFF
--- a/install.php
+++ b/install.php
@@ -8,13 +8,18 @@
 
 session_start(); 
 require_once('Functions.class.php');
-$_ = array();
-foreach($_POST as $key=>$val){
-$_[$key]=Functions::secure($val);
+$_ = array_merge($_GET, $_POST);
+$whiteList = array(
+	/* La liste blanche recense les variables ne devant pas être passées via
+	   la sécurisation, mais simplement échappées pour Php. */
+	'mysqlHost', 'mysqlLogin', 'mysqlMdp', 'mysqlBase', 'mysqlPrefix',
+);
+foreach($_ as $key=>&$val){
+ $val = in_array($key, $whiteList)
+	? str_replace("'", "\'", $val)
+	: Functions::secure($val);
 }
-foreach($_GET as $key=>$val){
-$_[$key]=Functions::secure($val);
-}
+
 ?>
 
 


### PR DESCRIPTION
N'effectue aucune protection dans les variables destinées à être
enregistrées dans le fichier de configuration. Sauf l'échappement des
quotes pour que le code soit valide en Php.
