### PR TITLE
Convertit les &agrave; et autres entités en leur équivalents UTF8.

### DIFF
--- a/templates/marigolds/footer.html
+++ b/templates/marigolds/footer.html
@@ -8,7 +8,7 @@
 
 	<div id="footer-container">
 		<footer class="wrapper">
-			<p>Leed "Light Feed" fabuleux agr&eacute;gateur ex&eacute;cut&eacute; en {$executionTime} secondes par <a target="_blank" href="http://blog.idleman.fr">Idleman</a> | <a href="about.php">A propos</a></p>
+			<p>Leed "Light Feed" fabuleux agrégateur exécuté en {$executionTime} secondes par <a target="_blank" href="http://blog.idleman.fr">Idleman</a> | <a href="about.php">A propos</a></p>
 		</footer>
 	</div>
 </div>

--- a/templates/marigolds/header.html
+++ b/templates/marigolds/header.html
@@ -7,7 +7,7 @@
 	<title>Leed V1.0</title>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=100,chrome=1">
-	<meta name="description" content="Agr&eacute;gateur de flux RSS Leed">
+	<meta name="description" content="Agrégateur de flux RSS Leed">
 	<meta name="author" content="IdleMan">
 	<link rel="shortcut icon" type="image/png" href="favicon.png">
 	<meta name="viewport" content="width=device-width">
@@ -16,7 +16,7 @@
 </head>
 <body>
 	<div class="global-wrapper">
-		<!-- <!> Balise ayant double utilit&eacute; : sert de base a javascript pour connaitre l'action courante permet le retour en haut de page -->
+		<!-- <!> Balise ayant double utilité : sert de base a javascript pour connaitre l'action courante permet le retour en haut de page -->
 		<a name="pageTopAnvil" id="pageTopAnvil"></a>
 		<a name="pageTop" id="pageTop" class="hidden">{$action}</a>
 		<div id="header-container">
@@ -28,7 +28,7 @@
 						<input type="text" class="miniInput left" name="login" placeholder="Identifiant"/> <input type="password" class="miniInput left" name="password" placeholder="Mot de passe"/> <button class="left">GO!!</button>
 				</form>
 				{else}
-					<span>Identifi&eacute; avec <span>{$myUser->getLogin()}</span></span><button onclick="window.location='action.php?action=logout'">D&eacute;connexion</button>
+					<span>Identifié avec <span>{$myUser->getLogin()}</span></span><button onclick="window.location='action.php?action=logout'">Déconnexion</button>
 				{/if}
 				<div class="clear"></div>
 				</div>


### PR DESCRIPTION
Hello,

Le dernier patch a remis les entités. Ce n'est plus utile vu que les fichiers sont (ou devrait être) en UTF8. Seules restent utiles, sauf exception, les entités HTML et autres non-alphabétiques.

Script utilisé (attention il y a parfois des entités à conserver) :
for f in $(find -type f -regextype posix-egrep -iregex '.*.(php|html?|js|css)$')
do
    sed -ie "s/&eacute;/é/g" "$f"
    sed -ie "s/&acirc;/â/g" "$f"
    sed -ie "s/&agrave;/à/g" "$f"
    sed -ie "s/&ecirc;/ê/g" "$f"
    sed -ie "s/&egrave;/è/g" "$f"
    sed -ie "s/&ocirc;/ô/g" "$f"
done
