### PR TITLE
Correction d'un bug lors de l'ajout manuel d'un feed

### DIFF
--- a/action.php
+++ b/action.php
@@ -340,7 +340,7 @@ switch ($action){
 					(isset($_['newUrlCategory'])?$_['newUrlCategory']:1)
 				);
 				$newFeed->save();
-				$newFeed->parse(true);
+				$newFeed->parse(time(), true);
 			}
  			header('location: ./settings.php#manageBloc');
 	break;


### PR DESCRIPTION
PHP renvoyait une erreur d'assertion non valide. J'ai rajouté syncId=time() qui manquait en argument de feed->parse().
