### PR TITLE
Rend la connexion indépendante des sessions

### DIFF
--- a/User.class.php
+++ b/User.class.php
@@ -31,15 +31,31 @@ class User extends MysqlEntity{
 		return $userManager->load(array('login'=>$login,'password'=>User::encrypt($password)));
 	}
 
-	function existAuthToken($auth){
+	function getToken() {
+		assert('!empty($this->password)');
+		assert('!empty($this->login)');
+		return sha1($this->password.$this->login);
+	}
+
+	function existAuthToken($auth=null){
 		$result = false;
 		$userManager = new User();
 		$users = $userManager->populate('id');
+		if (empty($auth)) $auth = @$_COOKIE['leedStaySignedIn'];
+		error_log($auth);
 		foreach($users as $user){
-		
-			if(sha1($user->getPassword().$user->getLogin())==$auth) $result = $user;
+			if($user->getToken()==$auth) $result = $user;
 		}
 		return $result;
+	}
+
+	function setStayConnected() {
+		///@TODO: set the current web directory, here and on del
+		setcookie('leedStaySignedIn', $this->getToken(), time()+31536000);
+	}
+	
+	static function delStayConnected() {
+		setcookie('leedStaySignedIn', '', -1);
 	}
 	
 	function getId(){

--- a/action.php
+++ b/action.php
@@ -471,6 +471,7 @@ switch ($action){
 				exit("erreur identification : le compte est inexistant");
 			}else{
 				$_SESSION['currentUser'] = serialize($user);
+				$user->setStayConnected();
 			}
 			header('location: ./index.php');	
 		}

--- a/common.php
+++ b/common.php
@@ -32,6 +32,7 @@ $myUser = (isset($_SESSION['currentUser'])?unserialize($_SESSION['currentUser'])
 $feedManager = new Feed();
 $eventManager = new Event();
 $userManager = new User();
+if (empty($myUser)) $myUser = $userManager->existAuthToken();
 $folderManager = new Folder();
 $configurationManager = new Configuration();
 $conf = $configurationManager->getAll();


### PR DESCRIPTION
Note technique : je n'ai fait aucune amélioration sur l'existant, ni
corrigé, ni améliorié, ni commenté. Le jeu de modification est minimal.

Principe : la session Php a une durée de vie limitée, puisqu'elle relie
le navigateur au serveur. En l'absence du navigateur, elle expire. Pour
prolonger la connexion, un cookie stocke une donnée ne pouvant être
connue que par celui qui connaît le compte et le mot de passe. Il est
normalement difficile de remonter au compte et au mot de passe, bien que
cette partie devrait être salée.
