### PR TITLE
Ajout d'un panneau d'aide pour les raccourcis clavier

### DIFF
--- a/templates/marigolds/css/style.css
+++ b/templates/marigolds/css/style.css
@@ -731,3 +731,29 @@ footer a,#main aside a{
 article #loader{
 	display: none;
 }
+
+/* =============================================================================
+   Help panel
+   ========================================================================== */
+#helpPanel {
+    background: #333;
+    opacity: 0.9;
+    filter:alpha(opacity=90); /* For IE8 and earlier */
+    color: #fff;
+    padding: 20px;
+    -webkit-border-radius: 20px;
+    -moz-border-radius: 20px;
+    border-radius: 20px;
+    position: fixed;
+    left: 50%;
+    top: 50%;
+    width: 500px;
+    height: 400px;
+    margin-top: -200px; /* moitié de la hauteur */
+    margin-left: -250px; /* moitié de la largeur */
+    z-Index: 1;
+	display: none;
+}
+#helpPanel strong {
+    color: #ff0;
+}

--- a/templates/marigolds/index.html
+++ b/templates/marigolds/index.html
@@ -10,6 +10,22 @@
 {if="($configurationManager->get('articleDisplayAnonymous')=='1') || ($myUser!=false)"}
 
 		
+		<div id="helpPanel">
+			<h3>Raccourcis clavier</h3>
+			<ul>
+				<li> <strong>m</strong> marque l'élément sélectionné comme lu / non lu</li>
+				<li> <strong>l</strong> marque l'élément précédent comme non lu</li>
+				<li> <strong>s</strong> marque l'élément sélectionné comme favori / non favori</li>
+				<li> <strong>n</strong> élément suivant (sans l'ouvrir)</li>
+				<li> <strong>v</strong> ouvre l'URL de l'élément sélectionné</li>
+				<li> <strong>p</strong> élément précédent (sans l'ouvrir)</li>
+				<li> <strong>MAJ + espace</strong> élément précédent (et l'ouvrir)</li>
+				<li> <strong>espace</strong> élément suivant (et l'ouvrir)</li>
+				<li> <strong>k</strong> élément précédent (et l'ouvrir)</li>
+				<li> <strong>o</strong> ou <strong>enter</strong> ouvrir l'élément sélectionné</li>
+				<li> <strong>h</strong> faire apparaître/masquer ce panneau d'aide</li>
+			</ul>
+		</div>
 
 		<div id="main" class="wrapper clearfix index">
 			<!--      -->

--- a/templates/marigolds/js/script.js
+++ b/templates/marigolds/js/script.js
@@ -14,6 +14,7 @@ keyCode['v'] = 86;
 keyCode['p'] = 80;
 keyCode['k'] = 75;
 keyCode['o'] = 79;
+keyCode['h'] = 72;
 keyCode['space'] = 32;
 
 $(document).ready(function(){
@@ -144,6 +145,11 @@ if(e.which == keyCode['shift']) isMaj=false;
         case keyCode['enter']:
             //ouvrir l'élément sélectionné
             openTargetEvent();
+            return false;
+        break;
+        case keyCode['h']:
+            //ouvrir/fermer le panneau d'aide
+            document.getElementById( 'helpPanel' ).style.display == 'block' ? document.getElementById( 'helpPanel' ).style.display = 'none' : document.getElementById( 'helpPanel' ).style.display = 'block';
             return false;
         break;
     }


### PR DESCRIPTION
Note : patch d'origine de kvnco

Je propose l'ajout d'un panneau d'aide indiquant les raccourcis claviers
utilisables dans l'application.
Le panneau est affichable/masquable en appuyant sur 'h'.
Il apparaître en "pop under" par dessus le fil des tickets.
