### PR TITLE
Met en clair le mot de passe dans les préférences

### DIFF
--- a/templates/marigolds/settings.html
+++ b/templates/marigolds/settings.html
@@ -115,7 +115,7 @@
 					<section>
 						<h3>{function="_t('USER')"}</h3>
 						<p><label for="login">{function="_t('LOGIN')"} :</label> <input type="text" id="login" name="login" value="{$myUser->getLogin()}"></p>
-						<p><label for="password">{function="_t('PASSWORD')"} :</label> <input type="text" id="password" name="password" autocomplete="off" value=""></p>
+						<p><label for="password">{function="_t('PASSWORD')"} :</label> <input type="text" id="password" name="password" autocomplete="off" value="" placeholder="(sera affiché en clair)"></p>
 						<h4>{function="_t('LET_EMPTY_IF_NO_PASS_CHANGE')"}</h4>
 					
 					</section>


### PR DESCRIPTION
Lorsqu'on est dans la fenêtre des préférences, c'est nécessairement
parce qu'on est au calme. De plus, on peut y aller quand on veut et on
peut choisir le moment du changement de mot de passe.

Aussi, il n'est pas nécessaire de cacher le mot de passe à cet endroit.
