### PR TITLE
Conditionnement de l'envoi de la variable articleView

### DIFF
--- a/action.php
+++ b/action.php
@@ -174,7 +174,8 @@ switch ($action){
             //Ajout des préférences et réglages
             $configurationManager->put('root',(substr($_['root'], strlen($_['root'])-1)=='/'?$_['root']:$_['root'].'/'));
             //$configurationManager->put('view',$_['view']);
-            $configurationManager->put('articleView',$_['articleView']);
+            if(isset($_['articleView']))
+                $configurationManager->put('articleView',$_['articleView']);
             $configurationManager->put('articleDisplayContent',$_['articleDisplayContent']);
             $configurationManager->put('articleDisplayAnonymous',$_['articleDisplayAnonymous']);
 


### PR DESCRIPTION
- à la validation du formulaire, si l'input articleView est
  disabled, la variable n'est pas soumise au serveur,
  entraînant une notice à la récupération côté PHP
