### PR TITLE
Condition me semblant inutile sur la récupération du lien

### DIFF
--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ $tpl->assign('articleDisplayFolderSort',$configurationManager->get('articleDispl
 $target = MYSQL_PREFIX.'event.title,'.MYSQL_PREFIX.'event.unread,'.MYSQL_PREFIX.'event.favorite,'.MYSQL_PREFIX.'event.feed,';
 if($articleDisplayContent && $articleView=='partial') $target .= MYSQL_PREFIX.'event.description,';
 if($articleDisplayContent && $articleView!='partial') $target .= MYSQL_PREFIX.'event.content,';
-if($articleDisplayLink) $target .= MYSQL_PREFIX.'event.link,';
+$target .= MYSQL_PREFIX.'event.link,';
 if($articleDisplayDate) $target .= MYSQL_PREFIX.'event.pubdate,';
 if($articleDisplayAuthor) $target .= MYSQL_PREFIX.'event.creator,';
 $target .= MYSQL_PREFIX.'event.id';


### PR DESCRIPTION
Le lien doit toujours bien être affiché quelque part. Quand le contenu d'un event n'est pas affiché et que la
vue est en "liste", le titre n'a du coup plus aucun lien.
