### PR TITLE
Purge les états des plugins inexistants

### DIFF
--- a/Plugin.class.php
+++ b/Plugin.class.php
@@ -40,6 +40,18 @@ class Plugin{
         $stateFile = dirname(__FILE__).Plugin::FOLDER.'/plugins.states.json';
         file_put_contents($stateFile,json_encode($states));
     }
+    public static function pruneStates() {
+        $statesBefore = self::getStates();
+        $statesAfter = array();
+        $error = false;
+        foreach($statesBefore as $file=>$state) {
+            if (file_exists($file))
+                $statesAfter[$file] = $state;
+            else
+                $error = true;
+        }
+        if ($error) self::setStates($statesAfter);
+    }
 
 
     private static function getObject($pluginFile){

--- a/settings.php
+++ b/settings.php
@@ -23,6 +23,10 @@ $tpl->assign('articleDisplayHomeSort', $configurationManager->get('articleDispla
 $tpl->assign('articleDisplayFolderSort', $configurationManager->get('articleDisplayFolderSort'));
 $tpl->assign('articleDisplayContent', $configurationManager->get('articleDisplayContent'));
 $tpl->assign('articleView', $configurationManager->get('articleView'));
+
+//Suppression de l'état des plugins inexistants
+Plugin::pruneStates();
+
 //Récuperation des plugins
 $tpl->assign('plugins',Plugin::getAll());
 


### PR DESCRIPTION
Si on supprime le répertoire d'un plugin, la mémoire de son état
(stockée dans plugins.states.json) sera aussi supprimée.

Cela permet de supprimer un plugin en effaçant simplement son
répertoire.

Note : je ne suis pas expert en greffon, et bien que je pense avoir une bonne idée de là où j'ai mis mes doigts boudinés, les commentaires sont bienvenus pour :
- valider la pertinence de cette fonctionnalité
- tester la fonctionnalité
- revoir le codage de celle-ci
