### PR TITLE
Remove obligation to put something between plugin and php on plugins filename

### DIFF
--- a/Plugin.class.php
+++ b/Plugin.class.php
@@ -187,7 +187,7 @@ class Plugin{
     public static function getFiles($onlyActivated=false){
 
         $enabled = $disabled =  array();
-        $files = glob(dirname(__FILE__). Plugin::FOLDER .'/*/*.plugin.*.php');
+        $files = glob(dirname(__FILE__). Plugin::FOLDER .'/*/*.plugin*.php');
         if(empty($files))
             $files = array();
 


### PR DESCRIPTION
I remember that we used that a long time ago to check if the plugin
was enabled or disabled, but now with the plugins.states.json file
I don't think we need it anymore. I would love to remove the last
catch all (*) but it's better to keep it to be able to load old
plugins.
