### PR TITLE
Fait disparaître l'événement lu avant le XHR

### DIFF
--- a/templates/marigolds/js/script.js
+++ b/templates/marigolds/js/script.js
@@ -435,8 +435,6 @@ function readThis(element,id,from,callback){
                         $(window).scrollTop($(document).height());
                     }
                 });
-                // on compte combien d'article ont été lus afin de les soustraires de la requête pour le scroll infini
-                $(window).data('nblus', $(window).data('nblus')+1);
                 // on diminue le nombre d'article en haut de page
                 $('#nbarticle').html(parseInt($('#nbarticle').html()) - 1)
         }
@@ -450,6 +448,8 @@ function readThis(element,id,from,callback){
                     if( console && console.log && msg!="" ) console.log(msg);
                     switch (activeScreen){
                         case '':
+                            // on compte combien d'article ont été lus afin de les soustraires de la requête pour le scroll infini
+                            $(window).data('nblus', $(window).data('nblus')+1);
                         break;
                         case 'selectedFolder':
                         case 'selectedFeedNonLu':


### PR DESCRIPTION
Ceci est une simple preuve de concept. N'étant pas rompu à la partie que j'ai modifiée, je soumet l'idée même de la fonctionnalité à l'accord collégial ainsi que sa pertinence techniquement parlant.

Le clic sur "Lu/Non lu" fait maintenant tout de suite disparaître
l'événement plutôt que d'attendre la fin de la requête réseau.

Il peut y avoir des cas où la connexion n'est pas faite, impliquant
que l'événement disparaît à l'écran mais réapparaîtra par la suite.
Hormis cela, la réactivité est immédiate quand on est sur une connexion
lente.
