### PR TITLE
Désactive le cache de flux

### DIFF
--- a/install.php
+++ b/install.php
@@ -202,7 +202,7 @@ if (isset($_['installButton']) && empty($test[$lib_errors])) { // Pas d'erreur, 
     $configurationManager->add('feedMaxEvents','50');
     $configurationManager->add('optionFeedIsVerbose',1);
     $configurationManager->add('synchronisationCode',$synchronisationCode);
-    $configurationManager->add('synchronisationEnableCache','1');
+    $configurationManager->add('synchronisationEnableCache','0');
     $configurationManager->add('synchronisationForceFeed','0');
     $configurationManager->add('synchronisationType','auto');
     $configurationManager->add('root',$root);


### PR DESCRIPTION
NOTE : quelqu'un voit un intérêt à activer le cache dans Leed ? Je crois qu'on pourrait carrément supprimer cette option.

Le cache de flux est utile lorsqu'il y peut y avoir plusieurs
sollicitations très rapprochées ET que les émetteurs ne se synchronisent
pas entre eux. Par exemple, un programme peut posséder diverses
sous-routines pour accéder aux flux qui sont développées par des équipes
différentes et dont les fonctions ne communiquent pas.

Dans Leed, il n'y a qu'un seul point d'entrée pour la synchronisation.
Lorsqu'arrive une synchronisation rapprochée, c'est voulu. Le cache n'a
alors pas d'intérêt, par défaut.

On peut mettre du temps à comprendre pourquoi on ne recevait pas les
mises à jour d'un flux alors qu'elles étaient visibles sur le flux
lui-même.
