### PR TITLE
FilterProvider support for both version 2.2 and 2.4 of apache

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -124,46 +124,51 @@ AddType text/x-vcard                        vcf
   </IfModule>
 
   # HTML, TXT, CSS, JavaScript, JSON, XML, HTC:
-#  <IfModule filter_module>
-#    FilterDeclare   COMPRESS
-# There are two way to configure the filters, according to the Apache version.
-# Apache >= 2.4
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/html
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/css
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/plain
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/xml
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/x-component
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/javascript
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/json
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xml
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xhtml+xml
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/rss+xml
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/atom+xml
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/vnd.ms-fontobject
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $image/svg+xml
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $image/x-icon
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/x-font-ttf
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $font/opentype
-# Apache <= 2.2
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/html
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/css
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/plain
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/xml
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/x-component
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/javascript
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/json
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xml
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xhtml+xml
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/rss+xml
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/atom+xml
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/vnd.ms-fontobject
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $image/svg+xml
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $image/x-icon
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/x-font-ttf
-#     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $font/opentype
-#    FilterChain     COMPRESS
-#    FilterProtocol  COMPRESS  DEFLATE change=yes;byteranges=no
-#  </IfModule>
+  # There are two way to configure the filters, according to the Apache version.
+  <IfModule version.c>
+    <IfModule filter_module>
+      FilterDeclare   COMPRESS
+      <IfVersion >= 2.4>
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$text/html'"
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$text/css'"
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$text/plain'"
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$text/xml'"
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$text/x-component'"
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$application/javascript'"
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$application/json'"
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$application/xml'"
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$application/xhtml+xml'"
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$application/rss+xml'"
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$application/atom+xml'"
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$application/vnd.ms-fontobject'"
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$image/svg+xml'"
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$image/x-icon'"
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$application/x-font-ttf'"
+        FilterProvider  COMPRESS  DEFLATE "%{CONTENT_TYPE} ='$font/opentype'"
+      </IfVersion>
+      <IfVersion <= 2.2>
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/html
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/css
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/plain
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/xml
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/x-component
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/javascript
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/json
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xml
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xhtml+xml
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/rss+xml
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/atom+xml
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/vnd.ms-fontobject
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $image/svg+xml
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $image/x-icon
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/x-font-ttf
+        FilterProvider  COMPRESS  DEFLATE resp=Content-Type $font/opentype
+      </IfVersion>
+      FilterChain     COMPRESS
+      FilterProtocol  COMPRESS  DEFLATE change=yes;byteranges=no
+    </IfModule>
+  </IfModule>
+
 
   <IfModule !mod_filter.c>
     # Legacy versions of Apache


### PR DESCRIPTION
Après une petite mise à jour vers apache 2.4, j'ai été obligé de modifier le .htaccess,  au niveau de FilterProvider, en m'aidant de cette page http://www.lazaruscorporation.co.uk/blogs/arts-tech/posts/upgrading-from-apache-2-2-to-apache-2-4
