### PR TITLE
Fait s'afficher le 'lu/non lu' des longs articles

### DIFF
--- a/templates/marigolds/article.html
+++ b/templates/marigolds/article.html
@@ -65,20 +65,22 @@
             <div class="articleContent content" style="display: none;"></div>
         {/if}
 
-        {if="$articleDisplayMode=='content'"}
-        <!-- RAPPEL DETAILS + OPTIONS POUR LES ARTICLES AFFICHES EN ENTIER -->
+        {if="$articleDisplayMode!='title'"}
+        <!-- RAPPEL DETAILS + OPTIONS POUR LES ARTICLES PLUS LONGS QUE LE TITRE -->
         <h3 class="articleDetails">
         {else}
         <h3 class="articleDetails" style="display: none;">
         {/if}
             {function="Plugin::callHook("event_pre_bottom_options", array(&$value))"}
 
-            <a class="pointer right readUnreadButton">({function="_t('READ')"}/{function="_t('UNREAD')"})</a>
-            {if="$value->getFavorite()!=1"}<a class="right pointer favorite"  onclick="addFavorite(this,{$value->getId()});">{function="_t('FAVORIZE')"}</a>
-            {else}
-            <a class="right pointer favorite" onclick="removeFavorite(this,{$value->getId()});">{function="_t('UNFAVORIZE')"}</a>
+            {if="strlen($value->getContent())>3000 || strlen($value->getDescription())>3000"}
+                <a class="pointer right readUnreadButton">({function="_t('READ')"}/{function="_t('UNREAD')"})</a>
+                {if="$value->getFavorite()!=1"}<a class="right pointer favorite"  onclick="addFavorite(this,{$value->getId()});">{function="_t('FAVORIZE')"}</a>
+                {else}
+                <a class="right pointer favorite" onclick="removeFavorite(this,{$value->getId()});">{function="_t('UNFAVORIZE')"}</a>
+                {/if}
+                <div class="clear"></div>
             {/if}
-            <div class="clear"></div>
             {function="Plugin::callHook("event_post_bottom_options", array(&$value))"}
         </h3>
     </section>


### PR DESCRIPTION
Actuellement, seuls les articles affichés entièrement disposent du
'lu/non lu' en pied d'articles. Mais certains flux, comme PCInpact, ont
aussi un résumé long. Cette validation pose comme principe la longueur
de l'article pour afficher ou non le pied d'article.

J'ai fixé arbitrairement la longueur du contenu à 3000 caractères,
balises y compris.

Si cette maquette est acceptée, il faudra définir dans la classe Event
la notion d'article long et simplement tester cette propriété à
l'affichage.

AJOUT : Comme il se doit, ne pas fusionner ! Le code actuel devra être remanié, vu qu'il y a une constante arbitraire dans la page. Il faut juste me dire si le principe de la modification est acceptable, si oui, je modifierai cette branche. Lorsque la fonctionnalité sera au point, je rebaserai.
