### PR TITLE
FIX mail's catch with number

### DIFF
--- a/Plugin.class.php
+++ b/Plugin.class.php
@@ -69,21 +69,15 @@ class Plugin{
         $plugin = new Plugin();
         $fileLines = file_get_contents($pluginFile);
 
-        if(preg_match_all("#@author\s(.+)\s\<#", $fileLines, $matches)) {
+        if(preg_match_all("#@author\s(.+)\s\<(.*)\>#", $fileLines, $matches)) {
             foreach($matches[1] as $match) {
                 $authors[] = trim($match);
             }
-            if(count($authors) == 1)
-                $authors = implode('', $authors);
             $plugin->setAuthor($authors);
-        }
 
-        if(preg_match_all("#@author\s(.+)\s\<(.*)\>#", $fileLines, $matches)) {
             foreach($matches[2] as $match) {
                 $address[] = strtolower($match);
             }
-            if(count($address) == 1)
-                $address = implode('', $address);
             $plugin->setAddress($address);
         }
 

--- a/templates/marigolds/settings.html
+++ b/templates/marigolds/settings.html
@@ -307,11 +307,9 @@
                             {$addresses=$value->getAddress()}
                             {if="is_array($authors)"}
                                 {loop="authors"}
-                                    {$mail_address=$addresses[$key2]}
-                                    <li><h4>{function="_t('AUTHOR')"}: </h4>{if="$mail_address"}<a href="{if="strpos($mail_address, '@')"}mailto:{/if}{$mail_address}">{/if}{$value}{if="$mail_address"}</a>{/if}</li>
+                                    {$address=$addresses[$key2]}
+                                    <li><h4>{function="_t('AUTHOR')"}: </h4>{if="$address"}<a href="{if="strpos($address, '@')"}mailto:{/if}{$address}">{/if}{$value}{if="$address"}</a>{/if}</li>
                                 {/loop}
-                            {else}
-                                <li><h4>{function="_t('AUTHOR')"}: </h4><a href="mailto:{$addresses}">{$authors}</a></li>
                             {/if}
                             <li><h4>{function="_t('LICENCE')"}: </h4>{$value->getLicence()}</li>
                             <li><h4>{function="_t('VERSION')"}: </h4><code>{$value->getVersion()}</code></li>


### PR DESCRIPTION
Correction du bug (déjà présent avant ma PR) trouvé par @cobalt74 (https://github.com/ldleman/Leed/pull/361#issuecomment-3809202) lorsqu'il y avait des chiffres dans le mail.
J'ai supprimé la validation qui me semblait inutile. Il sera plus simple de faire la modification demandée dans #363.

J'en ai profité pour modifier le template de marigolds pour qu'il n'affiche les mails que s'il y a quelque chose entre les <>.
