### PR TITLE
Règle le tri dans un dossier : non-lus ET date

### DIFF
--- a/article.php
+++ b/article.php
@@ -54,15 +54,8 @@ switch($action){
     case 'selectedFeed':
         $currentFeed = $feedManager->getById($_['feed']);
         $allowedOrder = array('date'=>'pubdate DESC','older'=>'pubdate','unread'=>'unread DESC,pubdate DESC');
-        $order = (isset($_['order'])?$allowedOrder[$_['order']]:$allowedOrder['date']);
+        $order = (isset($_['order'])?$allowedOrder[$_['order']]:$allowedOrder['unread']);
         $events = $currentFeed->getEvents($startArticle,$articlePerPages,$order,$target);
-    break;
-    /* AFFICHAGE DES EVENEMENTS D'UN FLUX EN PARTICULIER en mode non lus */
-    case 'selectedFeedNonLu':
-        $currentFeed = $feedManager->getById($_['feed']);
-        $filter = array('unread'=>1, 'feed'=>$currentFeed->getId());
-        $order = 'pubdate DESC';
-        $events = $eventManager->loadAllOnlyColumn($target,$filter,$order,$startArticle.','.$articlePerPages);
     break;
     /* AFFICHAGE DES EVENEMENTS D'UN DOSSIER EN PARTICULIER */
     case 'selectedFolder':

--- a/index.php
+++ b/index.php
@@ -72,7 +72,7 @@ switch($action){
         $tpl->assign('currentFeed',$currentFeed);
         $numberOfItem = $eventManager->rowCount(array('feed'=>$currentFeed->getId()));
         $allowedOrder = array('date'=>'pubdate DESC','older'=>'pubdate','unread'=>'unread DESC,pubdate DESC');
-        $order = (isset($_['order'])?$allowedOrder[$_['order']]:$allowedOrder['date']);
+        $order = (isset($_['order'])?$allowedOrder[$_['order']]:$allowedOrder['unread']);
         $page = (isset($_['page'])?$_['page']:1);
         $pages = ceil($numberOfItem/$articlePerPages);
         $startArticle = ($page-1)*$articlePerPages;
@@ -81,19 +81,6 @@ switch($action){
         $tpl->assign('order',(isset($_['order'])?$_['order']:''));
 
     break;
-    /* AFFICHAGE DES EVENEMENTS D'UN FLUX EN PARTICULIER en mode non lus */
-    case 'selectedFeedNonLu':
-        $currentFeed = $feedManager->getById($_['feed']);
-        $tpl->assign('currentFeed',$currentFeed);
-        $filter = array('unread'=>1, 'feed'=>$currentFeed->getId());
-        $numberOfItem = $eventManager->rowCount($filter);
-        $order = 'pubdate DESC';
-        $page = (isset($_['page'])?$_['page']:1);
-        $pages = ceil($numberOfItem/$articlePerPages);
-        $startArticle = ($page-1)*$articlePerPages;
-        $events = $eventManager->loadAllOnlyColumn($target,$filter,$order,$startArticle.','.$articlePerPages);
-
-        break;
     /* AFFICHAGE DES EVENEMENTS D'UN DOSSIER EN PARTICULIER */
     case 'selectedFolder':
         $currentFolder = $folderManager->getById($_['folder']);

--- a/templates/marigolds-old/index.html
+++ b/templates/marigolds-old/index.html
@@ -176,7 +176,7 @@
                 <!-- ENTETE ARTICLE -->
                 <header class="articleHead">
 
-                {if="$action=='selectedFeed' || ($action=='selectedFeedNonLu')"}
+                {if="$action=='selectedFeed'"}
                 <!-- AFFICHAGE DES EVENEMENTS D'UN FLUX EN PARTICULIER -->
 
 
@@ -184,7 +184,7 @@
                     <div class="clear"></div>
                         {$currentFeed->getDescription()}
                             {function="_t('SEE_THE')"}
-                    <a href="index.php?action=selectedFeedNonLu&amp;feed={$_['feed']}&amp;page={$page}">{function="ucfirst(_t('UNREAD'))"}</a> |
+                    <a href="index.php?action=selectedFeed&amp;feed={$_['feed']}&amp;page={$page}&amp;order=unread">{function="ucfirst(_t('UNREAD'))"}</a> |
                     <a href="index.php?action=selectedFeed&amp;feed={$_['feed']}&amp;page={$page}&amp;order=older">{function="_t('OLDER')"}</a> {function="_t('IN_FIRST')"}
                 {/if}
 

--- a/templates/marigolds-old/js/script.js
+++ b/templates/marigolds-old/js/script.js
@@ -511,7 +511,7 @@ function readThis(element,id,from,callback){
                             $(window).data('nblus', $(window).data('nblus')+1);
                         break;
                         case 'selectedFolder':
-                        case 'selectedFeedNonLu':
+                        case 'selectedFeed':
                             parent.addClass('eventRead');
                             if(callback){
                                 callback();
@@ -548,7 +548,7 @@ function readThis(element,id,from,callback){
                             if( console && console.log && msg!="" ) console.log(msg);
                             parent.removeClass('eventRead');
                             // on compte combien d'article ont été remis à non lus
-                            if ((activeScreen=='') || (activeScreen=='selectedFolder')|| (activeScreen=='selectedFeedNonLu'))
+                            if ((activeScreen=='') || (activeScreen=='selectedFolder')|| (activeScreen=='selectedFeed'))
                                 $(window).data('nblus', $(window).data('nblus')-1);
                             if(callback){
                                 callback();
@@ -576,7 +576,7 @@ function unReadThis(element,id,from){
                         if( console && console.log && msg!="" ) console.log(msg);
                         parent.removeClass('eventRead');
                         // on compte combien d'article ont été remis à non lus
-                        if ((activeScreen=='') || (activeScreen=='selectedFolder')|| (activeScreen=='selectedFeedNonLu'))
+                        if ((activeScreen=='') || (activeScreen=='selectedFolder')|| (activeScreen=='selectedFeed'))
                             $(window).data('nblus', $(window).data('nblus')-1);
 
                         addOrRemoveFeedNumber('+');

--- a/templates/marigolds/index.html
+++ b/templates/marigolds/index.html
@@ -176,7 +176,7 @@
                 <!-- ENTETE ARTICLE -->
                 <header class="articleHead">
 
-                {if="$action=='selectedFeed' || ($action=='selectedFeedNonLu')"}
+                {if="$action=='selectedFeed'"}
                 <!-- AFFICHAGE DES EVENEMENTS D'UN FLUX EN PARTICULIER -->
 
 
@@ -184,7 +184,7 @@
                    
                         {$currentFeed->getDescription()} <div class="clear"></div>
                             {function="_t('SEE_THE')"}
-                    <a href="index.php?action=selectedFeedNonLu&amp;feed={$_['feed']}&amp;page={$page}">{function="ucfirst(_t('UNREAD'))"}</a> |
+                    <a href="index.php?action=selectedFeed&amp;feed={$_['feed']}&amp;page={$page}&amp;order=unread">{function="ucfirst(_t('UNREAD'))"}</a> |
                     <a href="index.php?action=selectedFeed&amp;feed={$_['feed']}&amp;page={$page}&amp;order=older">{function="_t('OLDER')"}</a> {function="_t('IN_FIRST')"}
                 {/if}
 

--- a/templates/marigolds/js/script.js
+++ b/templates/marigolds/js/script.js
@@ -522,7 +522,7 @@ function readThis(element,id,from,callback){
                             $(window).data('nblus', $(window).data('nblus')+1);
                         break;
                         case 'selectedFolder':
-                        case 'selectedFeedNonLu':
+                        case 'selectedFeed':
                             if(callback){
                                 callback();
                             }else{
@@ -557,7 +557,7 @@ function readThis(element,id,from,callback){
                             if( console && console.log && msg!="" ) console.log(msg);
                             parent.removeClass('eventRead');
                             // on compte combien d'article ont été remis à non lus
-                            if ((activeScreen=='') || (activeScreen=='selectedFolder')|| (activeScreen=='selectedFeedNonLu'))
+                            if ((activeScreen=='') || (activeScreen=='selectedFolder')|| (activeScreen=='selectedFeed'))
                                 $(window).data('nblus', $(window).data('nblus')-1);
                             if(callback){
                                 callback();
@@ -585,7 +585,7 @@ function unReadThis(element,id,from){
                         if( console && console.log && msg!="" ) console.log(msg);
                         parent.removeClass('eventRead');
                         // on compte combien d'article ont été remis à non lus
-                        if ((activeScreen=='') || (activeScreen=='selectedFolder')|| (activeScreen=='selectedFeedNonLu'))
+                        if ((activeScreen=='') || (activeScreen=='selectedFolder')|| (activeScreen=='selectedFeed'))
                             $(window).data('nblus', $(window).data('nblus')-1);
 
                         addOrRemoveFeedNumber('+');


### PR DESCRIPTION
Après un certain temps de non-consultation d'un dossier, on consulte deux ou trois articles. Mais il existe d'autres non-lus plus bas, qui descendent progressivement dans la liste. Pour les voir, il faut demander l'affichage des non-lus.

Je souhaite changer ce comportement. Par défaut, tout s'affiche mais le tri passe de _date_ à _non-lu_+_date_. Les non-lus apparaissent donc d'abord, triés par date, ensuite apparaissent les lus ordonnés pareil.

Il y a encore deux liens pour changer l'affichage. Le premier lien est en fait celui affiché par défaut ; cliquer dessus ne changera rien. Le deuxième est le même qu'avant, il affiche les plus vieux d'abord sans tri sur _non-lu_. Le tri d'avant, par défaut, affichant par ordre chronologique inverse n'est plus là.

__NE PAS FUSIONNER_ si ça convient, j'intégrerai ça via une fusion directe.
