### PR TITLE
Facto actions toujours effectuées avec $isAlwaysDisplayed

### DIFF
--- a/common.php
+++ b/common.php
@@ -98,6 +98,12 @@ $tpl->assign('folderManager',$folderManager);
 $tpl->assign('configurationManager',$configurationManager);
 $tpl->assign('synchronisationCode',$configurationManager->get('synchronisationCode'));
 
+$articleDisplayAnonymous = $configurationManager->get('articleDisplayAnonymous');
+$tpl->assign('articleDisplayAnonymous',$articleDisplayAnonymous);
+
+$isAlwaysDisplayed = ($articleDisplayAnonymous=='1') || ($myUser!=false);
+$tpl->assign('isAlwaysDisplayed',$isAlwaysDisplayed);
+
 //Récuperation et sécurisation de toutes les variables POST et GET
 $_ = array();
 foreach($_POST as $key=>$val){

--- a/index.php
+++ b/index.php
@@ -14,20 +14,22 @@ Plugin::callHook("index_pre_treatment", array(&$_));
 //Récuperation de l'action (affichage) demandée
 $action = (isset($_['action'])?$_['action']:'');
 $tpl->assign('action',$action);
-//Récuperation des dossiers de flux par ordre de nom
-$tpl->assign('folders',$folderManager->populate('name'));
-//Recuperation de tous les non Lu
-$tpl->assign('unread',$feedManager->countUnreadEvents());
-//recuperation de tous les flux
-$allFeeds = $feedManager->getFeedsPerFolder();
-$tpl->assign('allFeeds',$allFeeds);
-//recuperation de tous les flux par dossier
-$tpl->assign('allFeedsPerFolder',$allFeeds['folderMap']);
-//recuperation de tous les event nons lu par dossiers
-$tpl->assign('allEvents',$eventManager->getEventCountPerFolder());
-//utilisé pour récupérer le statut d'un feed dans le template (en erreur ou ok)
-$feedState = new Feed();
-$tpl->assign('feedState',$feedState);
+if($isAlwaysDisplayed) {
+    //Récuperation des dossiers de flux par ordre de nom
+    $tpl->assign('folders',$folderManager->populate('name'));
+    //Recuperation de tous les non Lu
+    $tpl->assign('unread',$feedManager->countUnreadEvents());
+    //recuperation de tous les flux
+    $allFeeds = $feedManager->getFeedsPerFolder();
+    $tpl->assign('allFeeds',$allFeeds);
+    //recuperation de tous les flux par dossier
+    $tpl->assign('allFeedsPerFolder',$allFeeds['folderMap']);
+    //recuperation de tous les event nons lu par dossiers
+    $tpl->assign('allEvents',$eventManager->getEventCountPerFolder());
+    //utilisé pour récupérer le statut d'un feed dans le template (en erreur ou ok)
+    $feedState = new Feed();
+    $tpl->assign('feedState',$feedState);
+}
 //afficher ou non le champ OTP
 $tpl->assign('otpEnabled', $configurationManager->get('otpEnabled'));
 
@@ -42,6 +44,9 @@ $displayOnlyUnreadFeedFolder = $configurationManager->get('displayOnlyUnreadFeed
 if (!isset($displayOnlyUnreadFeedFolder)) $displayOnlyUnreadFeedFolder=false;
 ($displayOnlyUnreadFeedFolder=='true')?$displayOnlyUnreadFeedFolder_reverse='false':$displayOnlyUnreadFeedFolder_reverse='true';
 $optionFeedIsVerbose = $configurationManager->get('optionFeedIsVerbose');
+
+$page = 0;
+$pages = 0;
 
 $tpl->assign('articleDisplayAuthor',$articleDisplayAuthor);
 $tpl->assign('articleDisplayDate',$articleDisplayDate);
@@ -112,6 +117,10 @@ switch($action){
         $wrongLogin = true;
     default:
         $wrongLogin = !empty($wrongLogin);
+        $tpl->assign('wrongLogin',$wrongLogin);
+        if(!$isAlwaysDisplayed) {
+            break;
+        }
         $filter = array('unread'=>1);
         if($optionFeedIsVerbose) {
             $numberOfItem = $eventManager->rowCount($filter);
@@ -128,7 +137,6 @@ switch($action){
             $events = $eventManager->getEventsNotVerboseFeed($startArticle,$articlePerPages,$order,$target);
         }
         $tpl->assign('numberOfItem',$numberOfItem);
-        $tpl->assign('wrongLogin',$wrongLogin);
 
     break;
 }

--- a/settings.php
+++ b/settings.php
@@ -38,7 +38,6 @@ $tpl->assign('folders',$folderManager->populate('name'));
 $tpl->assign('synchronisationType',$configurationManager->get('synchronisationType'));
 $tpl->assign('synchronisationEnableCache',$configurationManager->get('synchronisationEnableCache'));
 $tpl->assign('synchronisationForceFeed',$configurationManager->get('synchronisationForceFeed'));
-$tpl->assign('articleDisplayAnonymous', $configurationManager->get('articleDisplayAnonymous'));
 $tpl->assign('articleDisplayLink', $configurationManager->get('articleDisplayLink'));
 $tpl->assign('articleDisplayDate', $configurationManager->get('articleDisplayDate'));
 $tpl->assign('articleDisplayAuthor', $configurationManager->get('articleDisplayAuthor'));

--- a/templates/marigolds/index.html
+++ b/templates/marigolds/index.html
@@ -7,7 +7,7 @@
 -->
 
 
-{if="($configurationManager->get('articleDisplayAnonymous')=='1') || ($myUser!=false)"}
+{if="$isAlwaysDisplayed"}
 
 
         <div id="helpPanel" onclick="$(this).fadeOut(200);">

--- a/templates/marigolds/settings.html
+++ b/templates/marigolds/settings.html
@@ -6,7 +6,7 @@
  @description: Page de gestion de toutes les préférences/configurations administrateur
 -->
 
-{if="($configurationManager->get('articleDisplayAnonymous')=='1') || ($myUser!=false)"}
+{if="$isAlwaysDisplayed"}
 
 
         <div id="main" class="wrapper clearfix settings">


### PR DESCRIPTION
Hello,
Une facto récupérée sur une vieille branche où je suis en train de faire du tri. Elle permet de gérer à un seul endroit le mécanisme du choix d'un contenu toujours visible.