### PR TITLE
Rendre l'useragent plus discret

### DIFF
--- a/Feed.class.php
+++ b/Feed.class.php
@@ -77,7 +77,7 @@ class Feed extends MysqlEntity{
         $feed->enable_cache($enableCache);
         $feed->force_feed($forceFeed);
         $feed->set_feed_url($this->url);
-        $feed->set_useragent('Mozilla/4.0 Leed (LightFeed Aggregator) '.LEED_VERSION_NAME.' by idleman http://projet.idleman.fr/leed');
+        $feed->set_useragent('Mozilla/5.0 (X11; Ubuntu; Linux x86_64) Gecko/20100101 Firefox');
         $this->lastSyncInError = 0;
         $this->lastupdate = $_SERVER['REQUEST_TIME'];
         if (!$feed->init()) {


### PR DESCRIPTION
Bonjour,

Ceci améliore la discrétion car ce champ est "journalisé" par les serveurs web des différents flux RSS.

En effet, pour le propriétaire du serveur web, l'useragent est très intéressant et si il n'est pas assez discret il sera plus facilement en mesure de déterminer l'heure de votre tâche cron.

Sans cette modification, il serait également plus simple pour le propriétaire d'un site web de créer une action spécifique sur votre Leed (bannissement de son useragent par exemple).

Merci, cordialement,