### PR TITLE
Suppression du parsing initial à l'ajout d'un flux

### DIFF
--- a/Feed.class.php
+++ b/Feed.class.php
@@ -36,19 +36,6 @@ class Feed extends MysqlEntity{
         parent::__construct();
     }
 
-    /** @TODO: ne faire qu'un seul chargement avec SimplePie et récupérer les
-    même informations. Mettre le chargement en cache au moins d'une méthode
-    loadLeed() qui ne chargera qu'une seule fois. Voire même en déclenchement
-    retardé, au dernier moment. */
-    function getInfos(){
-        $xml = @simplexml_load_file($this->url);
-        if($xml!=false){
-            $n = $xml->xpath('channel/title'); $this->name = $n[0];
-            $d = $xml->xpath('channel/description'); $this->description = $d[0];
-            $w = $xml->xpath('channel/link'); $this->website = $w[0];
-        }
-    }
-
     function getError() { return $this->error; }
     function getLastSyncInError() { return $this->lastSyncInError; }
 

--- a/action.php
+++ b/action.php
@@ -301,7 +301,6 @@ switch ($action){
         $newFeed = new Feed();
         $newFeed->setUrl(Functions::clean_url($_['newUrl']));
         if ($newFeed->notRegistered()) {
-            $newFeed->getInfos();
             $newFeed->setFolder(
                 (isset($_['newUrlCategory'])?$_['newUrlCategory']:1)
             );


### PR DESCRIPTION
Salut,
J'aimerais bien avoir ton avis là dessus. J'ai des erreurs lorsque les champs n'existent pas dans le flux or ils sont correctement définis par la suite. Je ne vois donc pas à quoi cette étape sert mais je peux me tromper.
Merci d'avance.