### PR TITLE
SameSite: Strict et header pour désactiver FLoC

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,6 +7,8 @@
 # Use ChromeFrame if it's installed for a better experience for the poor IE folk
 
 <IfModule mod_headers.c>
+  # F*ck you Google!
+  Header always set Permissions-Policy: interest-cohort=()
   Header set X-UA-Compatible "IE=Edge,chrome=1"
   # mod_headers can't match by content-type, but we don't want to send this header on *everything*...
   <FilesMatch "\.(js|css|gif|png|jpe?g|pdf|xml|oga|ogg|m4a|ogv|mp4|m4v|webm|svg|svgz|eot|ttf|otf|woff|ico|webp|appcache|manifest|htc|crx|oex|xpi|safariextz|vcf)$" >

--- a/User.class.php
+++ b/User.class.php
@@ -8,6 +8,7 @@
 
 class User extends MysqlEntity{
 
+    const COOKIE_NAME = 'leedStaySignedIn';
     const OTP_INTERVAL = 30;
     const OTP_DIGITS   = 8;
     const OTP_DIGEST   = 'sha1';
@@ -165,7 +166,7 @@ class User extends MysqlEntity{
         $userManager = new User();
         $users = $userManager->populate('id');
         $phpAuth = strtolower(@$_SERVER['PHP_AUTH_USER']);
-        if (empty($auth)) $auth = @$_COOKIE['leedStaySignedIn'];
+        if (empty($auth)) $auth = @$_COOKIE[self::COOKIE_NAME];
         foreach($users as $user){
             if ($user->getToken()==$auth || strtolower($user->login)===$phpAuth){
                 $result = $user;
@@ -181,11 +182,11 @@ class User extends MysqlEntity{
 
     function setStayConnected() {
         ///@TODO: set the current web directory, here and on del
-        setcookie('leedStaySignedIn', $this->getToken(), time()+31536000);
+        header('Set-Cookie: ' . self::COOKIE_NAME . '=' . $this->getToken() . '; Expires=' . gmdate('D, d-M-Y H:i:s', time()+31536000) . '; Max-Age=31536000; SameSite=Strict');
     }
 
     static function delStayConnected() {
-        setcookie('leedStaySignedIn', '', -1);
+        setcookie(self::COOKIE_NAME, '', -1);
     }
 
     function getId(){


### PR DESCRIPTION
Ça change la valeur `SameSite` pour ne l'envoyer explicitement que si le site est le notre. J'ai également ajouté le header pour dire à Google d'aller se faire voir avec son [FLoC](https://www.nextinpact.com/lebrief/46722/face-aux-floc-google-resistance-sorganise).