### PR TITLE
Shorten the "title" field to fit in the database

### DIFF
--- a/Event.class.php
+++ b/Event.class.php
@@ -160,7 +160,7 @@ class Event extends MysqlEntity{
     }
 
     function setTitle($title){
-        $this->title = $title;
+        $this->title = mb_substr($title, 0, self::LEN_STRING);
     }
 
     function getContent(){

--- a/MysqlEntity.class.php
+++ b/MysqlEntity.class.php
@@ -18,13 +18,14 @@ class MysqlEntity
     private $debug = false;
     private $debugAllQuery = false;
 
+    const LEN_STRING = 225;
 
     function sgbdType($type){
         $return = false;
         switch($type){
             case 'string':
             case 'timestamp':
-                $return = 'VARCHAR(225) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci';
+                $return = 'VARCHAR('.self::LEN_STRING.') CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci';
             break;
             case 'longstring':
                 $return = 'TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci';


### PR DESCRIPTION
Hello,

J’ai un flux qui comportait un titre plus long que le champs "title". Un _mb_substr_ règle le problème.

Quelque peut vérifier que l’intégration est bonne ?